### PR TITLE
Rewrite Purger

### DIFF
--- a/lib/tailwindcss/purger.rb
+++ b/lib/tailwindcss/purger.rb
@@ -1,8 +1,25 @@
+# frozen_string_literal: true
+
 class Tailwindcss::Purger
-  CLASS_NAME_PATTERN       = /([:A-Za-z0-9_-]+[\.\\\/:A-Za-z0-9_-]*)/
-  OPENING_SELECTOR_PATTERN = /\..*\{/
-  CLOSING_SELECTOR_PATTERN = /\s*\}/
-  NEWLINE = "\n"
+  CLASS_NAME_PATTERN = /[:A-Za-z0-9_-]+[\.]*[\\\/:A-Za-z0-9_-]*/
+
+  CLASS_BREAK = /(?![-_a-z0-9\\])/i # `\b` for class selectors
+
+  COMMENT = /#{Regexp.escape "/*"}.*?#{Regexp.escape "*/"}/m
+  COMMENTS_AND_BLANK_LINES = /\A(?:^#{COMMENT}?[ \t]*(?:\n|\z)|[ \t]*#{COMMENT})+/
+
+  AT_RULE = /@[^{]+/
+  CLASSLESS_SELECTOR_GROUP = /[^.{]+/
+  CLASSLESS_BEGINNING_OF_BLOCK = /\A\s*(?:#{AT_RULE}|#{CLASSLESS_SELECTOR_GROUP})\{\n?/
+
+  SELECTOR_GROUP = /[^{]+/
+  BEGINNING_OF_BLOCK = /\A#{SELECTOR_GROUP}\{\n?/
+
+  PROPERTY_NAME = /[-_a-z0-9]+/i
+  PROPERTY_VALUE = /(?:[^;]|;\S)+/
+  PROPERTIES = /\A(?:\s*#{PROPERTY_NAME}:#{PROPERTY_VALUE};\n?)+/
+
+  END_OF_BLOCK = /\A\s*\}\n?/
 
   attr_reader :keep_these_class_names
 
@@ -12,11 +29,15 @@ class Tailwindcss::Purger
     end
 
     def extract_class_names(string)
-      string.scan(CLASS_NAME_PATTERN).flatten.uniq.sort
+      string.scan(CLASS_NAME_PATTERN).uniq.sort!
     end
 
     def extract_class_names_from(files)
-      Array(files).flat_map { |file| extract_class_names(file.read) }.uniq.sort
+      Array(files).flat_map { |file| extract_class_names(file.read) }.uniq.sort!
+    end
+
+    def escape_class_selector(class_name)
+      class_name.gsub(/\A\d|[^-_a-z0-9]/, '\\\\\0')
     end
   end
 
@@ -25,40 +46,79 @@ class Tailwindcss::Purger
   end
 
   def purge(input)
-    inside_kept_selector = inside_ignored_selector = false
-    output = []
+    conveyor = Conveyor.new(input)
 
-    input.split(NEWLINE).each do |line|
-      case
-      when inside_kept_selector
-        output << line
-        inside_kept_selector = false if line =~ CLOSING_SELECTOR_PATTERN
-      when inside_ignored_selector
-        inside_ignored_selector = false if line =~ CLOSING_SELECTOR_PATTERN
-      when line =~ OPENING_SELECTOR_PATTERN
-        if keep_these_class_names.include? class_name_in(line)
-          output << line
-          inside_kept_selector = true
-        else
-          inside_ignored_selector = true
-        end
-      else
-        output << line
-      end
+    until conveyor.done?
+      conveyor.discard(COMMENTS_AND_BLANK_LINES) \
+      or conveyor.conditionally_keep(PROPERTIES) { conveyor.staged_output.last != "" } \
+      or conveyor.conditionally_keep(END_OF_BLOCK) { not conveyor.staged_output.pop } \
+      or conveyor.stage_output(CLASSLESS_BEGINNING_OF_BLOCK) \
+      or conveyor.stage_output(BEGINNING_OF_BLOCK) { |match| purge_beginning_of_block(match.to_s) } \
+      or raise "infinite loop"
     end
 
-    separated_without_empty_lines(output)
+    conveyor.output
   end
 
   private
-    def class_name_in(line)
-      CLASS_NAME_PATTERN.match(line)[1]
-        .remove("\\")
-        .remove(/:(focus|hover)(-within)?/)
-        .remove("::placeholder").remove("::-moz-placeholder").remove(":-ms-input-placeholder")
+    def keep_these_selectors_pattern
+      @keep_these_selectors_pattern ||= begin
+        escaped_classes = @keep_these_class_names.map { |name| Regexp.escape self.class.escape_class_selector(name) }
+        /(?:\A|,)[^.,{]*(?:[.](?:#{escaped_classes.join("|")})#{CLASS_BREAK}[^.,{]*)*(?=[,{])/
+      end
     end
 
-    def separated_without_empty_lines(output)
-      output.reject { |line| line.strip.empty? }.join(NEWLINE)
+    def purge_beginning_of_block(string)
+      purged = string.scan(keep_these_selectors_pattern).join
+      unless purged.empty?
+        purged.sub!(/\A,\s*/, "")
+        purged.rstrip!
+        purged << " {\n"
+      end
+      purged
+    end
+
+    class Conveyor
+      attr_reader :output, :staged_output
+
+      def initialize(input, output = +"")
+        @input = input
+        @output = output
+        @staged_output = []
+      end
+
+      def consume(pattern)
+        match = pattern.match(@input)
+        @input = match.post_match if match
+        match
+      end
+      alias :discard :consume
+
+      def stage_output(pattern)
+        if match = consume(pattern)
+          string = block_given? ? (yield match) : match.to_s
+          @staged_output << string
+          string
+        end
+      end
+
+      def keep(pattern)
+        if match = consume(pattern)
+          string = block_given? ? (yield match) : match.to_s
+          @output << @staged_output.shift until @staged_output.empty?
+          @output << string
+          string
+        end
+      end
+
+      def conditionally_keep(pattern)
+        keep(pattern) do |match|
+          (yield match) ? match.to_s : (break "")
+        end
+      end
+
+      def done?
+        @input.empty?
+      end
     end
 end


### PR DESCRIPTION
This rewrite accomplishes a few things:

* Fixes #20.  Closes #22.

* Purges selectors that aren't on the same line as their block brace:

    **Before**

    ```css
    .sm\:aspect-w-1,
    /* ... */
    .sm\:aspect-w-15 > *,
    @media (prefers-color-scheme: dark) {
    }
    ```

* Purges empty "at rule" blocks (e.g. empty `@media` blocks).

* Purges comments, except within property values.

* Adds support for nested selector blocks, to prepare for the future.
  For example, Tailwind has many `.group:hover .group-hover\:X` rules
  that could be written as `.group:hover { .group-hover\:X { ... } }`.

* Improves performance:

    **Before**

    ```bash
    $ bin/test -n test_basic_purge

    Finished in 2.307380s, 0.4334 runs/s, 3.0337 assertions/s.
    1 runs, 7 assertions, 0 failures, 0 errors, 0 skips
    ```

    **After**

    ```bash
    $ bin/test -n test_basic_purge

    Finished in 1.824162s, 0.5482 runs/s, 3.8374 assertions/s.
    1 runs, 7 assertions, 0 failures, 0 errors, 0 skips
    ```